### PR TITLE
Auto Semester in Calendar

### DIFF
--- a/frontend/app/calendar/page.tsx
+++ b/frontend/app/calendar/page.tsx
@@ -32,6 +32,11 @@ const CalendarUI: FC = () => {
     checkAuthentication().then(() => setIsLoading(false));
   }, [checkAuthentication]);
 
+  useEffect(() => {
+    const currentSemester = Object.values(terms)[0];
+    setTermFilter(currentSemester);
+  }, []);
+
   const handlePageChange = (page: number) => {
     if (page >= 1 && page <= totalPages) {
       setCurrentPage(page);


### PR DESCRIPTION
Added feature: when a user loads up Calendar the semester that should be preselected should be the current semester.