### PR TITLE
windsor/cos417

### DIFF
--- a/backend/majors/COS-AB.yaml
+++ b/backend/majors/COS-AB.yaml
@@ -125,7 +125,8 @@ req_list:
         explanation:
         course_list:
           - COS 316
-          - COS 318
+          - COS 318 # Deprecated (revamped to COS 417)
+          - COS 417
           - COS 375
           - COS 418
           - COS 461

--- a/backend/majors/COS-BSE.yaml
+++ b/backend/majors/COS-BSE.yaml
@@ -125,7 +125,8 @@ req_list:
     explanation: 
     course_list:
       - COS 316
-      - COS 318
+      - COS 318 # Deprecated (revamped to COS 417)
+      - COS 417
       - COS 375
       - COS 418
       - COS 461

--- a/backend/majors/ECE.yaml
+++ b/backend/majors/ECE.yaml
@@ -300,7 +300,7 @@ req_list:
 
       ECE473 / COS473 Elements of Decentralized Finance (S)<br>
       ECE 475 Computer Architecture (S)<br>
-      COS 318 Operating Systems (F)<br>
+      COS 417 Operating Systems (F)<br>
       COS 320 Compiling Techniques (S)<br>
       COS 461 Computer Networks (S)<br><br>
       
@@ -317,8 +317,8 @@ req_list:
       max_counted: 1
       min_needed: 2
       course_list:
-      - COS 318
       - COS 320
+      - COS 417
       - COS 461
       - ECE 368
       - ECE 462
@@ -326,7 +326,6 @@ req_list:
       - ECE 470
       - ECE 472
       - ECE 473 / COS 473
-      - COS 318
     - name: Breadth
       max_counted: 1
       min_needed: 1
@@ -334,8 +333,8 @@ req_list:
       - ECE 3**
       - ECE 4**
       excluded_course_list:
-      - COS 318
       - COS 320
+      - COS 417
       - COS 461
       - ECE 368
       - ECE 462
@@ -343,7 +342,6 @@ req_list:
       - ECE 470
       - ECE 472
       - ECE 473 / COS 473
-      - COS 318
       - ECE 397
       - ECE 398
       - ECE 497


### PR DESCRIPTION
Notes:
- COS 318 has been revamped to COS 417 by Professor [Mae Milano](https://arc.net/l/quote/reatirxg)
- Changed references of COS 318* to COS 417
- Fixed some erroneous duplicates in ECE.yaml

*Kept some legacy references COS 318 in the COS yaml files, in case people fiddle around with COS 318, which is still in our database. We should consider whether to keep or remove COS 318 from our systems.