### PR TITLE
now showing s2025 tab in calendar

### DIFF
--- a/frontend/store/filterSlice.ts
+++ b/frontend/store/filterSlice.ts
@@ -126,6 +126,7 @@ const useFilterStore = create<FilterState>()(
     }),
     {
       name: 'filter-settings',
+      version: 2
     }
   )
 );


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-82/spring-2025-missing-from-calendar-navbar

**Proposed Changes**
- version checking w/ zustand s.t. if user's localStorage doesn't match our info (i.e. missing s2025) it will update