### PR TITLE
Search by Major/Minor/Certificate Title in User Profile

### DIFF
--- a/frontend/components/MajorMinorSearch.tsx
+++ b/frontend/components/MajorMinorSearch.tsx
@@ -1,0 +1,23 @@
+
+import { MajorMinorType } from '@/types';
+
+// Function that performs a "smart search," allowing users to search for a major/minor both by the program's code (ex. COS)
+// and the program's precise name (ex. Computer Science).
+export const smartSearch = (
+    query: string,
+    options: MajorMinorType[]
+  ): MajorMinorType[] => { 
+    if (!query) return options;
+    const trimmedQuery = query.trim(); // Process the query (user's input), deleting whitespace as necessary.
+    if (trimmedQuery.length === 0) return options; 
+
+    return options.filter((option) => 
+        option.code.toUpperCase().startsWith(trimmedQuery.toUpperCase()) ||
+        option.name.toLowerCase().startsWith(trimmedQuery.toLowerCase())
+    );
+}
+
+export const isOptionEqual = (option: MajorMinorType, value: MajorMinorType): boolean => {
+    if (!option || !value) return false;
+    return option.code === value.code;
+};

--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -1,4 +1,5 @@
 import { FC, useState, useEffect, useCallback } from 'react';
+import { smartSearch, isOptionEqual } from './MajorMinorSearch';
 
 import {
   Autocomplete,
@@ -302,11 +303,13 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={false}
             autoHighlight
             options={majorOptions}
+            // Call smartSearch to search through all majors and determine matches for inputValue.
+            filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)}
             placeholder='Select your major'
             variant='soft'
             value={major}
             // inputValue={major.code === undeclared.code ? '' : major.code}
-            isOptionEqualToValue={(option, value) => option.code === value.code}
+            isOptionEqualToValue={isOptionEqual}
             onChange={(event, newMajor: MajorMinorType) => {
               event.stopPropagation();
               setMajor(newMajor ?? undeclared);
@@ -328,12 +331,12 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={true}
             autoHighlight
             options={minorOptions}
+            // Call smartSearch to search through all minors and determine matches for inputValue.
+            filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)} 
             placeholder={'Select your minor(s)'}
             variant='soft'
             value={minors}
-            isOptionEqualToValue={(option, value) =>
-              value === undefined || option.code === value.code
-            }
+            isOptionEqualToValue={isOptionEqual}
             onChange={(event, newMinors: MajorMinorType[]) => {
               event.stopPropagation();
               handleMinorsChange(event, newMinors);

--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -358,12 +358,12 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={true}
             autoHighlight
             options={certificateOptions}
+            // Call smartSearch to search through all minors and determine matches for inputValue.
+            filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)} 
             placeholder={'Select your certificate(s)'}
             variant='soft'
             value={certificates}
-            isOptionEqualToValue={(option, value) =>
-              value === undefined || option.code === value.code
-            }
+            isOptionEqualToValue={isOptionEqual}
             onChange={(event, newCertificates: MajorMinorType[]) => {
               event.stopPropagation();
               handleCertificatesChange(event, newCertificates);

--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -358,7 +358,7 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={true}
             autoHighlight
             options={certificateOptions}
-            // Call smartSearch to search through all minors and determine matches for inputValue.
+            // Call smartSearch to search through all certificates and determine matches for inputValue.
             filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)} 
             placeholder={'Select your certificate(s)'}
             variant='soft'


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-83/search-by-majorminorcertificate-title-in-user-profile

**Proposed Changes**
- Created a "smart search" function under MajorMinorSearch.tsx.
- Imported said function into UserSettings.tsx, so that users can search for majors/minors/certificates by both the code and name associated with a program.
