### PR TITLE
Pull constants out of localStorage

### DIFF
--- a/frontend/store/filterSlice.ts
+++ b/frontend/store/filterSlice.ts
@@ -2,12 +2,6 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface FilterState {
-  terms: { [key: string]: string };
-  termsInverse: { [key: string]: string };
-  distributionAreas: { [key: string]: string };
-  distributionAreasInverse: { [key: string]: string };
-  levels: { [key: string]: string };
-  gradingBases: string[];
   termFilter: string;
   distributionFilter: string;
   levelFilter: string[];
@@ -31,66 +25,6 @@ interface FilterState {
 const useFilterStore = create<FilterState>()(
   persist(
     (set) => ({
-      terms: {
-        'Spring 2025': '1254',
-        'Fall 2024': '1252',
-        'Spring 2024': '1244',
-        'Fall 2023': '1242',
-        'Spring 2023': '1234',
-        'Fall 2022': '1232',
-        'Spring 2022': '1224',
-        'Fall 2021': '1222',
-        'Spring 2021': '1214',
-        'Fall 2020': '1212',
-      },
-
-      termsInverse: {
-        '1252': 'Fall 2024',
-        '1242': 'Fall 2023',
-        '1232': 'Fall 2022',
-        '1222': 'Fall 2021',
-        '1212': 'Fall 2020',
-        '1254': 'Spring 2025',
-        '1244': 'Spring 2024',
-        '1234': 'Spring 2023',
-        '1224': 'Spring 2022',
-        '1214': 'Spring 2021',
-      },
-
-      distributionAreas: {
-        'Social Analysis': 'SA',
-        'Science & Engineering - Lab': 'SEL',
-        'Science & Engineering - No Lab': 'SEN',
-        'Quant & Comp Reasoning': 'QCR',
-        'Literature and the Arts': 'LA',
-        'Historical Analysis': 'HA',
-        'Ethical Thought & Moral Values': 'EM',
-        'Epistemology & Cognition': 'EC',
-        'Culture & Difference': 'CD',
-      },
-
-      distributionAreasInverse: {
-        SA: 'Social Analysis',
-        SEL: 'Science & Engineering - Lab',
-        SEN: 'Science & Engineering - No Lab',
-        QCR: 'Quant & Comp Reasoning',
-        LA: 'Literature and the Arts',
-        HA: 'Historical Analysis',
-        EM: 'Ethical Thought & Moral Values',
-        EC: 'Epistemology & Cognition',
-        CD: 'Culture & Difference',
-      },
-
-      levels: {
-        '100': '1',
-        '200': '2',
-        '300': '3',
-        '400': '4',
-        '500': '5',
-      },
-
-      gradingBases: ['A-F', 'P/D/F', 'Audit'],
-
       termFilter: '',
       distributionFilter: '',
       levelFilter: [],


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-108/use-constants-when-needed

**Proposed Changes**
- apparently the previous terms bug was the only thing that was using constants in localStorage, so deleted them from there to prevent future confusion (played around for a bit and made sure nothing broke)
