### PR TITLE
DEV-113: Fixing Bug in Major/Minor/Certificate Search

### DIFF
--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -331,6 +331,7 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={true}
             autoHighlight
             options={minorOptions}
+            filterSelectedOptions={true}
             // Call smartSearch to search through all minors and determine matches for inputValue.
             filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)} 
             placeholder={'Select your minor(s)'}
@@ -358,6 +359,7 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
             multiple={true}
             autoHighlight
             options={certificateOptions}
+            filterSelectedOptions={true}
             // Call smartSearch to search through all certificates and determine matches for inputValue.
             filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)} 
             placeholder={'Select your certificate(s)'}


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-113/deleting-majorminorcertificate-in-user-profile

**Proposed Changes**
- I added the line "filterSelectedOptions={true}" to both the Minor Autocomplete and the Certificate Autocomplete; now, if a user has minor/certificate x in their profile, when they conduct a search for more minors/certificates, x will not appear in the search list. (The bug described in the task doesn't seem to appear while performing a major search, but please let me know if I should add the aforementioned line to the Major Autocomplete.)
