### PR TITLE
DEV-106: new calendar search on term switch

### DIFF
--- a/frontend/app/calendar/CalendarSearch.tsx
+++ b/frontend/app/calendar/CalendarSearch.tsx
@@ -86,10 +86,12 @@ const CalendarSearch: FC = () => {
   }));
 
   const {
+    termFilter,
     distributionFilter,
     levelFilter,
     gradingFilter,
     showPopup,
+    setTermFilter,
     setDistributionFilter,
     setLevelFilter,
     setGradingFilter,
@@ -143,7 +145,7 @@ const CalendarSearch: FC = () => {
     } else {
       search('', filters);
     }
-  }, [query, distributionFilter, levelFilter, gradingFilter, search]);
+  }, [query, distributionFilter, levelFilter, gradingFilter, search, termFilter]);
 
   function retrieveCachedSearch(search: string) {
     setCalendarSearchResults(searchCache.get(search) || []);


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-106/reset-calendar-filters-when-changing-semester

**Proposed Changes**
- we had a bug where searching for course, switching terms, and adding it would add course to old semester
- so, use dependency array to make a new query when the term is updated
