### PR TITLE
Insert Courses from JSON

### DIFF
--- a/backend/compass/views.py
+++ b/backend/compass/views.py
@@ -626,9 +626,78 @@ def parse_semester(semester_id, class_year):
 
     return semester_num
 
+def parse_transcript_semester(semester_name):
+    # transcript json for semester looks like `2021-2022 Fall` instead of `Fall 2021`
+    # likewise, convert `2021-2022 Spring` to `Spring 2022`
+    year, term = semester_name.split(' ')
+    start_year, end_year = year.split('-')
+    if (term == "Fall"):
+        return f"{term} {start_year}"
+    else:
+        return f"{term} {end_year}"
+
+
+def update_transcript_courses(request):
+    try:
+        data = json.loads(request.body)
+        net_id = request.session['net_id']
+        user_inst = CustomUser.objects.get(net_id=net_id)
+        class_year = user_inst.class_year
+
+        # for testing
+        # data = {
+        #     '2023-2024 Fall': ['COS 126', 'CWR 201', 'ECO 312', 'EGR 301'],
+        #     '2023-2024 Spring': ['COS 226', 'MAT 217', 'MAT 378', 'ORF 309', 'WRI 192'],
+        #     '2024-2025 Fall': ['COS 217', 'COS 511', 'MAT 320', 'ORF 405'],
+        #     '2024-2025 Spring': ['COS 240', 'GER 211', 'MAT 325', 'ORF 307', 'PHI 301'],
+        #     '2025-2026 Fall': ['COS 333', 'COS 514', 'ORF 526', 'POL 210'],
+        #     '2025-2026 Spring': ['COS 398', 'COS 418', 'ENG 319', 'ORF 515', 'ORF 523']
+        # }
+
+        for semester, courses in data.items():
+            # ex: convert `2021-2022 Fall` to `Fall 2021`
+            semester = parse_transcript_semester(semester)
+            # convert to bin number
+            semester = parse_semester(semester, class_year)
+
+            for course_name in courses:
+                course_inst = (
+                    Course.objects.select_related('department')
+                    # icontains and not iexact because ORF 309 not found with ORF 309 / EGR 309 / MAT 380
+                    .filter(crosslistings__icontains=course_name, usercourses__user=user_inst)
+                    .order_by('-guid')
+                    .first()
+                )
+                if not course_inst:
+                    course_inst = (
+                        Course.objects.select_related('department')
+                        .filter(crosslistings__icontains=course_name)
+                        .order_by('-guid')
+                        .first()
+                    )
+
+                user_course, created = UserCourses.objects.update_or_create(
+                    user=user_inst, course=course_inst, defaults={'semester': semester}
+                )
+                if created:
+                    message = f'User course added: {semester}, {course_name}, {net_id}'
+                else:
+                    message = f'User course updated: {semester}, {course_name}, {net_id}'
+
+        return JsonResponse({'status': 'success', 'message': message})
+                
+
+    except Exception as e:
+        # Log the detailed error internally
+        logger.error(f'An internal error occurred: {e}', exc_info=True)
+
+        # Return a generic error message to the user
+        return JsonResponse({'status': 'error', 'message': 'An internal error has occurred!'})
+
 
 def update_courses(request):
     try:
+        # update_transcript_courses(request)
         data = json.loads(request.body)
         crosslistings = data.get('crosslistings')  # might have to adjust this, print
         container = data.get('semesterId')


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-101/insert-courses-from-json

**Proposed Changes**
- Added `update_transcript_courses` method that takes in the output from the json transcript parser and inserts each course into the database with its corresponding semester bin. Frontend updates on page reload.
- The original `parse_semester` method expects input like "Fall 2021," but the JSON transcript parser outputs "2021-2022 Fall." The `parse_transcript_semester` method converts between these formats.