### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/backend/hoagieplan/api/calendar/configuration.py
+++ b/backend/hoagieplan/api/calendar/configuration.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from django.db.models.query import Prefetch
@@ -148,7 +149,8 @@ class CalendarConfigurationsView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
-            return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            logging.error("An error occurred: %s", str(e))
+            return Response({"detail": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class CalendarConfigurationView(APIView):
@@ -167,7 +169,8 @@ class CalendarConfigurationView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
         except Exception as e:
-            return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            logging.error("An error occurred: %s", str(e))
+            return Response({"detail": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def post(self, request):
         user = request.user

--- a/backend/hoagieplan/api/calendar/configuration.py
+++ b/backend/hoagieplan/api/calendar/configuration.py
@@ -1,4 +1,4 @@
-import logging
+from hoagieplan.logger import logger
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from django.db.models.query import Prefetch
@@ -149,7 +149,7 @@ class CalendarConfigurationsView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
-            logging.error("An error occurred: %s", str(e))
+            logger.error("An error occurred: %s", str(e))
             return Response({"detail": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
@@ -169,7 +169,7 @@ class CalendarConfigurationView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
         except Exception as e:
-            logging.error("An error occurred: %s", str(e))
+            logger.error("An error occurred: %s", str(e))
             return Response({"detail": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def post(self, request):


### PR DESCRIPTION
Fixes [https://github.com/HoagieClub/plan/security/code-scanning/1](https://github.com/HoagieClub/plan/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed exception message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling code that returns the exception message with code that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
