### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend/hoagieplan/api/profile/info.py
+++ b/backend/hoagieplan/api/profile/info.py
@@ -122,7 +122,8 @@ def profile(request):
         user_info = fetch_user_info(net_id)
         return JsonResponse(user_info)
     except UserProfileNotFoundError as e:
-        return JsonResponse({"error": str(e)}, status=404)
+        logger.error(f"UserProfileNotFoundError: {e}")
+        return JsonResponse({"error": "User profile not found"}, status=404)
     except Exception as e:
         logger.error(f"Error in profile view: {e}")
         return JsonResponse({"error": "Internal server error"}, status=500)


### PR DESCRIPTION
Fixes [https://github.com/HoagieClub/plan/security/code-scanning/4](https://github.com/HoagieClub/plan/security/code-scanning/4)

To fix the problem, we need to ensure that the error message returned to the user is generic and does not expose any sensitive information. The detailed error message should be logged on the server for debugging purposes. Specifically, we will:
1. Modify the code on line 125 to return a generic error message instead of the string representation of the exception.
2. Ensure that the detailed error message is logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
