### PR TITLE
math minor 400 level bug

### DIFF
--- a/backend/minors/MAT.yaml
+++ b/backend/minors/MAT.yaml
@@ -84,6 +84,7 @@ req_list:
   double_counting_allowed: false
   course_list:
   - MAT 3*
+  - MAT 4*
 - name: Junior Seminar
   max_counted: 1
   min_needed: 1


### PR DESCRIPTION
**References**
- Linear: n/a

**Proposed Changes**
- noticed that 400 level mat courses aren't counting towards the minor, one line fix
