### PR TITLE
DEV-135 Reduce Font Size for Calendar Card

### DIFF
--- a/frontend/app/calendar/Calendar.scss
+++ b/frontend/app/calendar/Calendar.scss
@@ -98,7 +98,7 @@ $box-shadow-hover:
   justify-content: space-between;
   border-radius: 8px;
   @include box-shadow($box-shadow-base);
-  padding: 8px;
+  padding: 4px 8px;
   margin: -1px;
   box-sizing: border-box;
   @include transition;

--- a/frontend/app/calendar/CalendarCard.tsx
+++ b/frontend/app/calendar/CalendarCard.tsx
@@ -69,12 +69,12 @@ const CalendarCard: FC<CalendarCardProps> = ({
           {event.section.class_section}
         </div>
 
-        <div className='mt-1 text-sm text-white/80'>
+        <div className='text-xs text-white/80'>
           {event.startTime} – {event.endTime}
         </div>
       </div>
 
-      <div className='capacity-container mt-1 flex items-center text-sm text-white/80'>
+      <div className='capacity-container flex items-center text-xs text-white/80'>
         <span className='capacity'>
           {event.section.enrollment} / {event.section.capacity}
         </span>


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-135/reduce-font-size-for-calendar-card

**Proposed Changes**
- Decreased top and bottom padding of .calendar-card in _frontend/app/calendar/Calendar.scss_ to 4px
- Changed font size of time and capacity elements to text-xs in _frontend/app/calendar/CalendarCard.tsx_
- Removed mt-1 from time and capacity elements in _frontend/app/calendar/CalendarCard.tsx_