### PR TITLE
Deleting Major/Minor/Certificate in User Profile

### DIFF
--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -378,14 +378,28 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
               handleMinorsChange(event, newMinors);
             }}
             getOptionLabel={(option: MajorMinorType) => option.code}
-            renderOption={(props, option) => (
-              <AutocompleteOption {...props} key={option.name}>
-                <ListItemContent>
-                  {option.code}
-                  <Typography level='body-sm'>{option.name}</Typography>
-                </ListItemContent>
-              </AutocompleteOption>
-            )}
+            renderOption={(props, option) => {
+                // Determine if current minor 'option' is already selected by the user.
+                const isAlreadySelected = minors.some(minor => minor.code === option.code);
+                return (
+                    <AutocompleteOption {...props} 
+                        key={option.name}
+                        component="li"
+                        // Disable the selection of and add custom styling (i.e. darkened background) to already selected minors.
+                        sx={{
+                            ...(isAlreadySelected && {
+                                color: 'darkgray',
+                                pointerEvents: 'none',
+                            })
+                        }}
+                        >
+                        <ListItemContent>
+                            {option.code}
+                            <Typography level='body-sm'>{option.name}</Typography>
+                        </ListItemContent>
+                    </AutocompleteOption>
+                );
+            }}
           />
         </div>
         <div>
@@ -405,14 +419,28 @@ const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => {
               handleCertificatesChange(event, newCertificates);
             }}
             getOptionLabel={(option: MajorMinorType) => option.code}
-            renderOption={(props, option) => (
-              <AutocompleteOption {...props} key={option.name}>
-                <ListItemContent>
-                  {option.code}
-                  <Typography level='body-sm'>{option.name}</Typography>
-                </ListItemContent>
-              </AutocompleteOption>
-            )}
+            renderOption={(props, option) => {
+                // Determine if current certificate 'option' is already selected by the user.
+                const isAlreadySelected = certificates.some(certificate => certificate.code === option.code);
+                return (
+                    <AutocompleteOption {...props} 
+                        key={option.name}
+                        component="li"
+                        // Disable the selection of and add custom styling (i.e. darkened background) to already selected certificates.
+                        sx={{
+                            ...(isAlreadySelected && {
+                                color: 'darkgray',
+                                pointerEvents: 'none',
+                            })
+                        }}
+                        >
+                        <ListItemContent>
+                            {option.code}
+                            <Typography level='body-sm'>{option.name}</Typography>
+                        </ListItemContent>
+                    </AutocompleteOption>
+                );
+            }}
           />
         </div>
         <Snackbar


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-113/deleting-majorminorcertificate-in-user-profile

**Proposed Changes**
- Edited the "renderOption" props of the Minor Autocomplete and the Certificate Autocomplete. Now, if a user already has selected a minor/certificate in their user profile settings, it will be "grayed-out/disabled" when they attempt to conduct a future search. This implementation should resolve the previous deletion bug, because already selected minors/certificates still appear in the search list but cannot be "clicked."
- I did not change the Major Autocomplete, since the bug described in the task does not seem to appear while performing a major search.
