### PR TITLE
DEV-166: Remove 'More Features' Section of Calendar Page

### DIFF
--- a/frontend/app/calendar/page.tsx
+++ b/frontend/app/calendar/page.tsx
@@ -84,22 +84,14 @@ const CalendarUI: FC = () => {
         </Pane>
       </div>
 
-      <main className='flex flex-grow'>
+      <main className='flex flex-grow justify-center'>
         <div className='flex h-full w-full'>
           <div>
             <CalendarSearch />
             <SelectedCourses />
           </div>
-
-          <div className='margin flex-grow'>
+          <div className='margin flex-grow pr-2'>
             {!isLoading && userProfile && userProfile.netId !== '' ? <Calendar /> : <SkeletonApp />}
-          </div>
-        </div>
-        <div className={tabStyles.tabContainer} style={{ width: '20%' }}>
-          <div className={tabStyles.tabContent}>
-            <div className='text-sm font-medium text-gray-500'>
-              <strong>More calendar features</strong> will be available soon. Stay tuned!
-            </div>
           </div>
         </div>
       </main>


### PR DESCRIPTION
**References**
- Linear: [DEV-166](https://linear.app/hoagie/issue/DEV-166/remove-more-features-section)

**Proposed Changes**
- Removed the requested 'tabStyles.tabContainer' div from the Calendar page.
- Adjusted the margins to ensure that the rearranged calendar components remain centered on screen. (I am less sure of my implementation of this part; it seems that, without my addition of 'pr-2', the calendar always appears horizontally closer than the search area to the edges of the screen. If there is a better way to implement this, please let me know!)
