### PR TITLE
DEV-211: Removed empty semester to fix semester selection misalignment

### DIFF
--- a/frontend/utils/terms.ts
+++ b/frontend/utils/terms.ts
@@ -13,7 +13,6 @@ export const terms: { [key: string]: string } = {
 	'Fall 2021': '1222',
 	'Spring 2021': '1214',
 	'Fall 2020': '1212',
-	'': '',
 };
 
 export const termsInverse: { [key: string]: string } = {
@@ -31,5 +30,4 @@ export const termsInverse: { [key: string]: string } = {
 	'1222': 'Fall 2021',
 	'1214': 'Spring 2021',
 	'1212': 'Fall 2020',
-	'': '',
 };


### PR DESCRIPTION
**References**
- Linear: [DEV-211](https://linear.app/hoagie/issue/DEV-211/misaligned-semester-selection)

**Proposed Changes**
- Removed empty semester to remove rendering empty semester in the first page of the semester selection section in Calendar