### PR TITLE
DEV-680: Update insert_evals.py

### DIFF
--- a/backend/data/fetch_evals.py
+++ b/backend/data/fetch_evals.py
@@ -141,9 +141,8 @@ def save(data: str, term: str, course_id: str) -> None:
     _comments = scrape_comments(webpage)
     fieldnames = ["course_id", "term", "scores", "comments"]
 
-    # Ensure scores and comments are properly formatted as JSON strings
-    scores = oj.dumps(_scores).decode("utf-8").replace("\\/", "/")[1:-1]
-    comments = oj.dumps(_comments).decode("utf-8").replace("\\/", "/")[1:-1]
+    scores = oj.dumps(_scores).decode("utf-8")
+    comments = oj.dumps(_comments).decode("utf-8")
 
     with csv_lock:
         with open(EVALS_CSV, "a", newline="", encoding="utf-8") as file:

--- a/backend/data/insert_evals.py
+++ b/backend/data/insert_evals.py
@@ -50,15 +50,17 @@ def map_evaluation_fields(eval_data):
 
 def parse_evaluations(eval_str):
     try:
-        eval_data = oj.loads(f"{{{eval_str}}}")
+        eval_data = oj.loads(eval_str)
         return map_evaluation_fields(eval_data)
     except ValueError:
         return {}
 
 
 def parse_comments(comment_str):
-    comments = comment_str.strip().split('","')
-    return [comment.strip().strip('"') for comment in comments]
+    try:
+        return oj.loads(comment_str)
+    except ValueError:
+        return []
 
 
 def count_rows(file_path):

--- a/backend/data/insert_evals.py
+++ b/backend/data/insert_evals.py
@@ -16,7 +16,6 @@ django.setup()
 
 from hoagieplan.models import Course, CourseComment
 
-
 # Field mapping for CSV columns to Django model fields
 EVALUATION_FIELD_MAPPING = {
     "Quality of Course": "quality_of_course",
@@ -69,9 +68,6 @@ def count_rows(file_path):
 
 @transaction.atomic
 def import_data(evals):
-    print("Clearing existing CourseComment...")
-    CourseComment.objects.all().delete()
-
     total_rows = count_rows(evals)
     course_batch = []
     comment_batch = []
@@ -128,13 +124,12 @@ def import_data(evals):
             print(f"  ... and {len(missing_courses) - 10} more")
 
 
+# Usage: python insert_evals.py
+# Inserts scores and comments for courses in the CSV. Does not touch existing data.
 def main():
     parser = argparse.ArgumentParser(description="Import course evaluations from a CSV file")
     parser.add_argument(
-        "filename",
-        nargs="?",
-        default="./evals.csv",
-        help="Path to the evaluations CSV file (default: ./evals.csv)"
+        "filename", nargs="?", default="./evals.csv", help="Path to the evaluations CSV file (default: ./evals.csv)"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
**References**
- Linear: [DEV-680](https://linear.app/hoagie/issue/DEV-680/update-insert-evals-to-not-delete-existing-course-comments)

**Proposed Changes**
- Remove the deletion of all existing course comments in `insert_evals.py`
- Fix potential bug with splitting comments by comma and using json directly instead
