### PR TITLE
DEV-702 Allow calendars with unassigned P99 time to be exported

### DIFF
--- a/frontend/app/calendar/CalendarSearch.tsx
+++ b/frontend/app/calendar/CalendarSearch.tsx
@@ -229,18 +229,24 @@ export const CalendarSearch: FC = () => {
 		// All courses in the selected semester
 		const currentSemesterCourses = getSelectedCourses(termFilter);
 
-		// We need to make sure user doesn't have any unsettled courses
+		const hasMeetingTime = (course: (typeof currentSemesterCourses)[number]) => {
+			const meetings = course.section?.class_meetings;
+			return meetings && meetings.length > 0 && meetings[0]?.days && meetings[0].days.trim() !== '';
+		};
+
+		// We need to make sure user doesn't have any unsettled courses that have an assigned time
 		const hasUnselectedRequired = currentSemesterCourses.some(
-			(course) => course.isActive && course.needsChoice && !course.isChosen
+			(course) =>
+				course.isActive && course.needsChoice && !course.isChosen && hasMeetingTime(course)
 		);
 
 		if (hasUnselectedRequired) {
 			return null;
 		}
 
-		// Filter out sections that are active
+		// Filter out sections that are active and have an assigned meeting time
 		const class_sections = currentSemesterCourses.filter(
-			(course) => course.isChosen || !course.needsChoice
+			(course) => (course.isChosen || !course.needsChoice) && hasMeetingTime(course)
 		);
 
 		const seenSectionIds = new Set<number>();


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-702/allow-calendars-with-unassigned-p99-time-to-be-exported

**Proposed Changes**
- Calendar with SML301 could not be exported because the P99 precept was not assigned a time. 
- `hasUnselectedRequired`: ignores sections like P99 where days is empty — they have no time to "select", so they shouldn't block the export.
- `class_sections`: adds [hasMeetingTime(course)] to the filter, so sections with no assigned time are silently excluded from the exported calendar.
