### PR TITLE
DEV-739: Handle layout shifts

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -20,9 +20,7 @@ const Dashboard: FC = () => {
 				{profile && profile.netId !== '' ? ( // prob don't need to verify netId too
 					<Canvas profile={profile} columns={2} />
 				) : (
-					<div>
-						<SkeletonApp />
-					</div>
+					<SkeletonApp />
 				)}
 			</main>
 		</>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,7 +10,9 @@
  * and/or sell copies of the software. This software is provided "as-is", without warranty of any kind.
  */
 
+// @ts-ignore
 import './globals.css';
+// @ts-ignore
 import '@/lib/hoagie-ui/Theme/theme.css';
 
 import { type ReactNode, type JSX } from 'react';
@@ -30,6 +32,7 @@ import { Theme } from '@/lib/hoagie-ui/Theme';
 const poppins = Poppins({
 	weight: ['400', '500', '600', '700'],
 	subsets: ['latin'],
+	display: 'optional', // prevents font-swap CLS; uses fallback permanently on uncached visits
 });
 
 import type { Metadata } from 'next';
@@ -63,7 +66,12 @@ async function Content({ children }: { children: ReactNode }): Promise<JSX.Eleme
 		<Auth0Provider user={user}>
 			<Theme palette='plan'>
 				<Layout>
-					<Nav name='plan' tabs={tabs} user={user} />
+					{/* height 92px = Nav's 20px header strip + 72px (majorScale(9)) nav bar.
+					    Inline style avoids ui-box CSS-in-JS timing: if Evergreen styles load after first paint,
+					    Nav shrinks from auto-height to 92px and shifts `main` — this wrapper prevents that. */}
+					<div style={{ height: '92px', overflow: 'visible' }}>
+						<Nav name='plan' tabs={tabs} user={user} />
+					</div>
 					{children}
 					<Toaster />
 				</Layout>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -73,25 +73,33 @@ export default function Index() {
 	}
 
 	return (
-		<Pane
-			display='flex'
-			justifyContent='center'
-			alignItems='center'
-			marginX={majorScale(1)}
-			paddingBottom={majorScale(4)}
-			paddingTop={majorScale(8)}
+		<div
+			style={{
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				marginLeft: '8px',
+				marginRight: '8px',
+				paddingBottom: '32px',
+				paddingTop: '64px',
+			}}
 		>
-			<Pane
-				borderRadius={8}
-				textAlign='center'
-				elevation={1}
-				background='white'
-				marginX={20}
-				maxWidth='600px'
-				width='100%'
-				paddingX='10px'
-				paddingTop={majorScale(5)}
-				paddingBottom={majorScale(7)}
+			<div
+				style={{
+					borderRadius: '8px',
+					textAlign: 'center',
+					boxShadow: '0 0 1px rgba(67, 90, 111, 0.3), 0 2px 4px -2px rgba(67, 90, 111, 0.47)',
+					background: 'white',
+					marginLeft: '20px',
+					marginRight: '20px',
+					maxWidth: '600px',
+					width: '100%',
+					paddingLeft: '10px',
+					paddingRight: '10px',
+					paddingTop: '40px',
+					paddingBottom: '56px',
+					boxSizing: 'border-box',
+				}}
 			>
 				<Heading size={900} className='hoagie'>
 					Welcome to HoagiePlan
@@ -101,29 +109,34 @@ export default function Index() {
 					Explore courses, read reviews, and manage <br />
 					your four-year schedule.
 				</p>
-				<div>
-					<Pane display='flex' flexDirection='column' alignItems='center' marginTop='30px'>
-						{Profile}
-						<Link href='https://hoagie.io'>
-							<Button
-								height={56}
-								width={majorScale(35)}
-								appearance='default'
-								marginTop={20}
-								iconBefore={ArrowLeftIcon}
-							>
-								<Pane display='flex'>
-									Back to
-									<Pane marginLeft={minorScale(1)} className='hoagie'>
-										hoagie<b>platform</b>
-									</Pane>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+						marginTop: '30px',
+					}}
+				>
+					{Profile}
+					<Link href='https://hoagie.io'>
+						<Button
+							height={56}
+							width={majorScale(35)}
+							appearance='default'
+							marginTop={20}
+							iconBefore={ArrowLeftIcon}
+						>
+							<Pane display='flex'>
+								Back to
+								<Pane marginLeft={minorScale(1)} className='hoagie'>
+									hoagie<b>platform</b>
 								</Pane>
-							</Button>
-						</Link>
-						<br />
-					</Pane>
+							</Pane>
+						</Button>
+					</Link>
+					<br />
 				</div>
-			</Pane>
-		</Pane>
+			</div>
+		</div>
 	);
 }

--- a/frontend/components/SkeletonApp.tsx
+++ b/frontend/components/SkeletonApp.tsx
@@ -22,7 +22,7 @@ const theme = extendTheme({
 export const SkeletonApp: FC = () => {
 	return (
 		<CssVarsProvider theme={theme}>
-			<div style={{ display: 'flex', width: '100vw', height: '100vh' }}>
+			<div style={{ display: 'flex', width: '100%', height: '87vh' }}>
 				{/* Body container */}
 				<div style={{ display: 'flex', width: '100%', height: '100%' }}>
 					{/* Left sidebar with search bar */}
@@ -30,7 +30,7 @@ export const SkeletonApp: FC = () => {
 						<Skeleton variant='rectangular' height='100px' sx={{ mt: '10px', bgcolor: 'red' }} />
 						<Skeleton
 							variant='rectangular'
-							height='calc(100vh - 120px)'
+							height='calc(87vh - 125px)'
 							sx={{ mt: '2px', bgcolor: 'red' }}
 						/>
 					</div>
@@ -43,7 +43,7 @@ export const SkeletonApp: FC = () => {
 							gridAutoRows: '1fr',
 							gap: '25px',
 							width: '40%',
-							height: 'full',
+							height: '100%',
 							marginTop: '10px',
 							marginLeft: '10px',
 						}}
@@ -57,7 +57,7 @@ export const SkeletonApp: FC = () => {
 					<div style={{ width: '25%', marginRight: '12px', marginLeft: '22px' }}>
 						<Skeleton
 							variant='rectangular'
-							height='calc(100vh - 20px)'
+							height='calc(87vh - 22px)'
 							sx={{
 								mt: '10px',
 								bgcolor: 'red',

--- a/frontend/components/TabbedMenu/TabbedMenu.module.css
+++ b/frontend/components/TabbedMenu/TabbedMenu.module.css
@@ -1,5 +1,5 @@
 .tabContainer {
-	height: 100vh;
+	flex-grow: 1;
 	margin-top: 1vh;
 	margin-bottom: 1vh;
 	margin-left: 0.5vw;

--- a/frontend/lib/hoagie-ui/AuthButton/index.tsx
+++ b/frontend/lib/hoagie-ui/AuthButton/index.tsx
@@ -14,8 +14,6 @@ import type { FC } from 'react';
 
 import { Button, Pane, majorScale, minorScale } from 'evergreen-ui';
 
-import { hoagiePlan } from '@/lib/hoagie-ui/Theme/themes';
-
 interface AuthButtonProps {
 	/** defines whether the button is for "login" or "logout" */
 	variant?: string;
@@ -27,7 +25,6 @@ interface AuthButtonProps {
  * different Hoagie applications.
  */
 export const AuthButton: FC<AuthButtonProps> = ({ variant = 'login', href = '' }) => {
-	const theme = hoagiePlan;
 	const logo = (
 		<h2
 			style={{
@@ -48,7 +45,6 @@ export const AuthButton: FC<AuthButtonProps> = ({ variant = 'login', href = '' }
 			<Button
 				height={56}
 				width={majorScale(35)}
-				background={theme.colors.white}
 				appearance={isLogout ? 'default' : 'primary'}
 			>
 				{logo}

--- a/frontend/lib/hoagie-ui/AuthButton/index.tsx
+++ b/frontend/lib/hoagie-ui/AuthButton/index.tsx
@@ -42,11 +42,7 @@ export const AuthButton: FC<AuthButtonProps> = ({ variant = 'login', href = '' }
 		: '/auth/login?connection=Princeton-CAS&returnTo=/dashboard';
 	return (
 		<a href={href === '' ? defHref : href}>
-			<Button
-				height={56}
-				width={majorScale(35)}
-				appearance={isLogout ? 'default' : 'primary'}
-			>
+			<Button height={56} width={majorScale(35)} appearance={isLogout ? 'default' : 'primary'}>
 				{logo}
 				<Pane display='flex'>
 					{isLogout ? 'Logout from' : 'Login using'}

--- a/frontend/lib/hoagie-ui/Nav/index.tsx
+++ b/frontend/lib/hoagie-ui/Nav/index.tsx
@@ -85,24 +85,33 @@ export const Nav: FC<NavProps> = ({
 			{HeaderComponent ? (
 				<HeaderComponent />
 			) : (
-				<Pane width='100%' height={20} background={theme.title} />
+				// inline style avoids CSS-in-JS timing — header strip was rendering 0px then growing to 20px, shifting the nav bar down
+				<div style={{ width: '100%', height: '20px', background: theme.title }} />
 			)}
-			<Pane
-				display='flex'
-				justifyContent='center'
-				width='100%'
-				height={majorScale(9)}
-				background='white'
+			{/* inline styles avoid CSS-in-JS timing CLS — these three layout panes were
+			    shifting as Evergreen injected their styles after first paint */}
+			<div
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					width: '100%',
+					height: '72px',
+					background: 'white',
+				}}
 			>
-				<Pane
-					display='flex'
-					alignItems='center'
-					justifyContent='space-between'
-					width='100%'
-					height='100%'
-					maxWidth={1200}
-					paddingX={majorScale(5)}
-					fontSize={18}
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'space-between',
+						width: '100%',
+						height: '100%',
+						maxWidth: '1200px',
+						paddingLeft: '40px',
+						paddingRight: '40px',
+						fontSize: '18px',
+						boxSizing: 'border-box',
+					}}
 				>
 					<Link href='/'>
 						<Pane cursor='pointer' position='relative'>
@@ -125,7 +134,7 @@ export const Nav: FC<NavProps> = ({
 							)}
 						</Pane>
 					</Link>
-					<Pane display='flex' alignItems='center'>
+					<div style={{ display: 'flex', alignItems: 'center' }}>
 						<TabNavigation>
 							{tabs.map((tab) => (
 								<Tab
@@ -169,9 +178,9 @@ export const Nav: FC<NavProps> = ({
 							</Popover>
 						)}
 						{tutorialModal}
-					</Pane>
-				</Pane>
-			</Pane>
+					</div>
+				</div>
+			</div>
 			{settingsModal}
 		</Pane>
 	);


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-739/handle-layout-shifts

**Proposed Changes**
- Problem: Evergreen UI's CSS-in-JS library first renders raw elements based on a primitive Box component, only injecting the generated atomic styles into the document head dynamically via JavaScript. Layout-critical elements render at browser defaults, then snap to their correct sizes when styles load, causing cumulative layout shift (CLS). Initial CLS score was 0.921, target is ≤ 0.1.
- I converted the layout-critical `<Pane>` elements to native `<div> ` with inline styles.  Inline styles are embedded in the SSR HTML and available on first paint, eliminating the snap.