### PR TITLE
DEV-678 Info Component Popover UI

### DIFF
--- a/frontend/app/dashboard/SortableItem.tsx
+++ b/frontend/app/dashboard/SortableItem.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 
 import { DashboardSearchItem } from '@/components/DashboardSearchItem';
+import { InfoComponentPopOver } from '@/components/InfoComponent/InfoComponentPopOver';
 import { Item } from '@/components/Item';
 import type { Course } from '@/types';
 import { getPrimaryColor, getSecondaryColor } from '@/utils/departmentColors';
@@ -53,27 +54,34 @@ export function SortableItem({
 	// For search results, render DashboardSearchItem with Item as child
 	if (containerId === SEARCH_RESULTS_ID) {
 		const cleanId = id.toString().replace('|disabled', '');
+		const crosslisting = cleanId.split('|')[1] ?? cleanId;
 		return (
-			<DashboardSearchItem course={course}>
-				<Item
-					disabled={disabled}
-					ref={disabled ? undefined : setNodeRef}
-					value={cleanId}
-					dragging={isDragging}
-					sorting={isSorting}
-					handle={handle && !disabled}
-					handleProps={disabled ? undefined : setActivatorNodeRef}
-					index={index}
-					wrapperStyle={{ ...wrapperStyle({ index }), width: '100%' }}
-					color_primary={getPrimaryColor(cleanId)}
-					color_secondary={getSecondaryColor(cleanId)}
-					transition={transition}
-					transform={transform}
-					fadeIn={mountedWhileDragging}
-					listeners={disabled ? undefined : listeners}
-					onRemove={() => {}}
-				/>
-			</DashboardSearchItem>
+			<InfoComponentPopOver
+				value={crosslisting}
+				dept={course?.department_code}
+				coursenum={course ? String(course.catalog_number) : undefined}
+			>
+				<DashboardSearchItem course={course}>
+					<Item
+						disabled={disabled}
+						ref={disabled ? undefined : setNodeRef}
+						value={cleanId}
+						dragging={isDragging}
+						sorting={isSorting}
+						handle={handle && !disabled}
+						handleProps={disabled ? undefined : setActivatorNodeRef}
+						index={index}
+						wrapperStyle={{ ...wrapperStyle({ index }), width: '100%' }}
+						color_primary={getPrimaryColor(cleanId)}
+						color_secondary={getSecondaryColor(cleanId)}
+						transition={transition}
+						transform={transform}
+						fadeIn={mountedWhileDragging}
+						listeners={disabled ? undefined : listeners}
+						onRemove={() => {}}
+					/>
+				</DashboardSearchItem>
+			</InfoComponentPopOver>
 		);
 	}
 
@@ -82,6 +90,7 @@ export function SortableItem({
 			disabled={disabled}
 			ref={disabled ? undefined : setNodeRef}
 			value={id}
+			course={course}
 			dragging={isDragging}
 			sorting={isSorting}
 			handle={handle}

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "hoagieplan",
@@ -87,6 +88,12 @@
     "esbuild",
     "@parcel/watcher",
   ],
+  "overrides": {
+    "evergreen-ui": {
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0",
+    },
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,6 +1,5 @@
 {
-  "lockfileVersion": 3,
-  "configVersion": 0,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "name": "hoagieplan",
@@ -88,12 +87,6 @@
     "esbuild",
     "@parcel/watcher",
   ],
-  "overrides": {
-    "evergreen-ui": {
-      "react": "^19.0.0",
-      "react-dom": "^19.0.0",
-    },
-  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 

--- a/frontend/components/InfoComponent/InfoComponent.tsx
+++ b/frontend/components/InfoComponent/InfoComponent.tsx
@@ -149,7 +149,8 @@ export const InfoComponent: FC<InfoComponentProps> = ({ value }) => {
 				className={styles.modal}
 				style={{
 					width: '75%',
-					height: courseDetails ? '82vh' : '160px',
+					height: courseDetails ? '70vh' : '160px',
+					maxHeight: courseDetails ? '70vh' : '160px',
 					gap: '10px',
 					padding: '25px',
 					display: 'flex',

--- a/frontend/components/InfoComponent/InfoComponentPopOver.tsx
+++ b/frontend/components/InfoComponent/InfoComponentPopOver.tsx
@@ -65,9 +65,10 @@ export const InfoComponentPopOver: FC<InfoComponentPopOverProps> = ({
 	const [selectedTermIdx, setSelectedTermIdx] = useState(0);
 
 	// Per-term data (move up so it's available for useEffect)
-	const terms: TermEntry[] = Array.isArray(courseDetails?.['terms'])
-		? (courseDetails['terms'] as TermEntry[])
-		: [];
+	const terms: TermEntry[] = useMemo(
+		() => (Array.isArray(courseDetails?.['terms']) ? (courseDetails['terms'] as TermEntry[]) : []),
+		[courseDetails]
+	);
 
 	// Once terms load, default to the first (newest) term with student feedback,
 	// independent of backend ordering. Only runs once per course open — later
@@ -107,19 +108,9 @@ export const InfoComponentPopOver: FC<InfoComponentPopOverProps> = ({
 
 	const courseSetup: CourseSetupItem[] = selectedTerm?.course_setup ?? [];
 
-	// Per-term description and grading
-	const selectedDescription = Array.isArray(courseDetails?.descriptions)
-		? (courseDetails.descriptions[selectedTermIdx] ?? courseDetails['Description'])
-		: courseDetails?.['Description'];
-	// Prefer grading from selectedTerm if available, else fallback
-	let selectedGrading;
-	if (selectedTerm && Array.isArray((selectedTerm as any).grading)) {
-		selectedGrading = (selectedTerm as any).grading;
-	} else if (Array.isArray(courseDetails?.gradings)) {
-		selectedGrading = courseDetails.gradings[selectedTermIdx] ?? courseDetails['Grading'];
-	} else {
-		selectedGrading = courseDetails?.['Grading'];
-	}
+	// The backend returns a single Description/Grading for the course, not per-term.
+	const selectedDescription = courseDetails?.['Description'];
+	const selectedGrading = courseDetails?.['Grading'];
 
 	// Per-term student feedback (stars)
 	const selectedQuality = selectedTerm?.quality_of_course ?? null;
@@ -684,7 +675,7 @@ export const InfoComponentPopOver: FC<InfoComponentPopOverProps> = ({
 												flexDirection: 'column',
 											}}
 										>
-											{(selectedGrading as { label: string; percent: number }[]).map(
+											{(selectedGrading as unknown as { label: string; percent: number }[]).map(
 												(item, index, arr) => (
 													<div
 														key={item.label}

--- a/frontend/components/InfoComponent/InfoComponentPopOver.tsx
+++ b/frontend/components/InfoComponent/InfoComponentPopOver.tsx
@@ -1,0 +1,773 @@
+import React, { useEffect, useMemo, useRef, useState, type FC, type ReactNode } from 'react';
+
+import { Tooltip } from '@mui/joy';
+import { CircularProgress, Rating } from '@mui/material';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { createPortal } from 'react-dom';
+
+import { ReviewMenu } from '@/components/ReviewMenu';
+import { CourseDetailSection } from '@/components/ui/CourseDetailSection';
+import { CourseSetup } from '@/components/ui/CourseSetup';
+import { ExternalLink } from '@/components/ui/ExternalLink';
+import { SectionTitle } from '@/components/ui/SectionTitle';
+import SemesterTag, { SemesterType } from '@/components/ui/SemesterTag';
+import { getAuditColor, getAuditTag } from '@/utils/auditTag';
+import { getDepartmentGradient } from '@/utils/departmentColors';
+import { distributionAreasInverse } from '@/utils/distributionAreas';
+import { getDistributionColors } from '@/utils/distributionColors';
+import { getPdfColor, getPdfTag } from '@/utils/pdfTag';
+import { getRatingBackground } from '@/utils/ratingColors';
+
+interface InfoComponentPopOverProps {
+	value: string;
+	children: ReactNode;
+	// Explicit course identity, preferred over parsing `value` (which may be a
+	// display string listing every crosslisting, e.g. "COM 476 / LAS 376").
+	dept?: string;
+	coursenum?: string;
+}
+
+interface CourseSetupItem {
+	class_type: string;
+	count: number;
+	duration?: number;
+}
+
+interface TermEntry {
+	term_code: string;
+	label: string;
+	instructors: string[];
+	quality_of_course: number | null;
+	course_setup: CourseSetupItem[];
+}
+
+interface CourseDetails {
+	[key: string]: string | number | boolean | null | undefined | CourseSetupItem[] | TermEntry[];
+}
+
+const PANEL_WIDTH = 560;
+
+export const InfoComponentPopOver: FC<InfoComponentPopOverProps> = ({
+	value,
+	children,
+	dept: deptProp,
+	coursenum: coursenumProp,
+}) => {
+	const dept = deptProp ?? value.split(' ')[0];
+	const coursenum = coursenumProp ?? value.split(' ')[1];
+
+	const [showPopover, setShowPopover] = useState(false);
+	const [isVisible, setIsVisible] = useState(false);
+	const [courseDetails, setCourseDetails] = useState<CourseDetails | null>(null);
+	const [fetchError, setFetchError] = useState(false);
+	const [showScrollGradient, setShowScrollGradient] = useState(false);
+	const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
+	const [selectedTermIdx, setSelectedTermIdx] = useState(0);
+
+	// Per-term data (move up so it's available for useEffect)
+	const terms: TermEntry[] = Array.isArray(courseDetails?.['terms'])
+		? (courseDetails['terms'] as TermEntry[])
+		: [];
+
+	// Once terms load, default to the first (newest) term with student feedback,
+	// independent of backend ordering. Only runs once per course open — later
+	// manual selections via the dropdown are left alone.
+	const didAutoSelectTerm = useRef(false);
+	useEffect(() => {
+		if (didAutoSelectTerm.current || !terms.length) {
+			return;
+		}
+		didAutoSelectTerm.current = true;
+		const idx = terms.findIndex(
+			(term) => term.quality_of_course !== null && term.quality_of_course !== 0
+		);
+		setSelectedTermIdx(idx === -1 ? 0 : idx);
+	}, [terms]);
+	const [showTermDropdown, setShowTermDropdown] = useState(false);
+
+	const instanceId = useRef(Math.random());
+	const triggerRef = useRef<HTMLDivElement | null>(null);
+	const popoverScrollRef = useRef<HTMLDivElement>(null);
+
+	const distShort = String(courseDetails?.['Distribution Area'] ?? '')
+		.trim()
+		.toUpperCase();
+	const distColor = getDistributionColors(distShort);
+	const distTitle = distributionAreasInverse[distShort];
+	const gradingBasis = String(courseDetails?.['Grading Basis'] ?? '');
+	const pdfTag = getPdfTag(gradingBasis);
+	const pdfColor = getPdfColor(pdfTag);
+	const pdfTitle = pdfTag === 'PDF' ? 'PDF Available' : 'PDF Unavailable';
+	const auditTag = getAuditTag(gradingBasis);
+	const auditColor = getAuditColor(auditTag);
+	const auditTitle = auditTag === 'A' ? 'Audit Available' : 'Audit Unavailable';
+
+	// ...existing code...
+	const selectedTerm: TermEntry | undefined = terms[selectedTermIdx];
+
+	const courseSetup: CourseSetupItem[] = selectedTerm?.course_setup ?? [];
+
+	// Per-term description and grading
+	const selectedDescription = Array.isArray(courseDetails?.descriptions)
+		? (courseDetails.descriptions[selectedTermIdx] ?? courseDetails['Description'])
+		: courseDetails?.['Description'];
+	// Prefer grading from selectedTerm if available, else fallback
+	let selectedGrading;
+	if (selectedTerm && Array.isArray((selectedTerm as any).grading)) {
+		selectedGrading = (selectedTerm as any).grading;
+	} else if (Array.isArray(courseDetails?.gradings)) {
+		selectedGrading = courseDetails.gradings[selectedTermIdx] ?? courseDetails['Grading'];
+	} else {
+		selectedGrading = courseDetails?.['Grading'];
+	}
+
+	// Per-term student feedback (stars)
+	const selectedQuality = selectedTerm?.quality_of_course ?? null;
+	const selectedTermCode = selectedTerm?.term_code;
+
+	// Display the selected semester as the tag
+	let termTagSeason: SemesterType | undefined;
+	let termYear: number | undefined;
+	if (selectedTerm && selectedTerm.label) {
+		const [season, yearStr] = selectedTerm.label.split(' ');
+		if (season === SemesterType.Fall) {
+			termTagSeason = SemesterType.Fall;
+		} else if (season === SemesterType.Spring) {
+			termTagSeason = SemesterType.Spring;
+		} else {
+			termTagSeason = undefined;
+		}
+		termYear = yearStr ? parseInt(yearStr, 10) : undefined;
+	} else {
+		termTagSeason = undefined;
+		termYear = undefined;
+	}
+
+	const links = useMemo(() => {
+		const registrarValue = courseDetails?.Registrar;
+		if (typeof registrarValue !== 'string' || !registrarValue) {
+			return { registrar: null, princeton: null };
+		}
+
+		try {
+			const params = new URL(registrarValue).searchParams;
+			const term = params.get('term') ?? '';
+			const courseId = params.get('courseid') ?? '';
+
+			return {
+				registrar: registrarValue,
+				princeton:
+					term && courseId ? `https://www.princetoncourses.com/course/${term}${courseId}` : null,
+			};
+		} catch {
+			return { registrar: registrarValue, princeton: null };
+		}
+	}, [courseDetails]);
+
+	const checkScrollGradient = () => {
+		const el = popoverScrollRef.current;
+		if (!el) {
+			return;
+		}
+		setShowScrollGradient(
+			el.scrollHeight > el.clientHeight && el.scrollTop + el.clientHeight < el.scrollHeight - 2
+		);
+	};
+
+	const updatePopoverPosition = () => {
+		if (!triggerRef.current) {
+			return;
+		}
+
+		const rect = triggerRef.current.getBoundingClientRect();
+		const containerRect = (
+			triggerRef.current.closest('li') ?? triggerRef.current
+		).getBoundingClientRect();
+		const viewportPadding = 20;
+		const gap = 8;
+		const estimatedWidth = Math.min(PANEL_WIDTH, window.innerWidth - viewportPadding * 2);
+		const estimatedHeight = 560;
+
+		let left = containerRect.right + gap;
+		if (left + estimatedWidth > window.innerWidth - viewportPadding) {
+			left = Math.max(viewportPadding, containerRect.left - estimatedWidth - gap);
+		}
+
+		const idealTop = rect.top + rect.height / 2 - estimatedHeight / 2;
+		const top = Math.max(
+			viewportPadding,
+			Math.min(idealTop, window.innerHeight - viewportPadding - estimatedHeight)
+		);
+
+		setPopoverPosition({ top, left });
+	};
+
+	const togglePopover = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (showPopover) {
+			setIsVisible(false);
+			setTimeout(() => setShowPopover(false), 150);
+		} else {
+			updatePopoverPosition();
+			setShowPopover(true);
+			setFetchError(false);
+			requestAnimationFrame(() => setIsVisible(true));
+			window.dispatchEvent(new CustomEvent('popover-open', { detail: instanceId.current }));
+		}
+	};
+
+	useEffect(() => {
+		setCourseDetails(null);
+		setFetchError(false);
+		setShowScrollGradient(false);
+		setSelectedTermIdx(0);
+		didAutoSelectTerm.current = false;
+		setShowTermDropdown(false);
+	}, [value]);
+
+	useEffect(() => {
+		if (!courseDetails) {
+			return;
+		}
+		requestAnimationFrame(checkScrollGradient);
+	}, [courseDetails]);
+
+	useEffect(() => {
+		if (!showPopover || !value || courseDetails || fetchError) {
+			return;
+		}
+
+		const controller = new AbortController();
+
+		const fetchCourseDetails = async () => {
+			try {
+				const params = new URLSearchParams({ crosslistings: value });
+				const response = await fetch(`/api/hoagie/course/details?${params}`, {
+					signal: controller.signal,
+				});
+
+				if (!response.ok) {
+					throw new Error(`HTTP error: ${response.status}`);
+				}
+
+				const data = (await response.json()) as CourseDetails;
+				setCourseDetails(data);
+			} catch (error) {
+				if (controller.signal.aborted) {
+					return;
+				}
+
+				console.error('Error fetching course details:', error);
+				setFetchError(true);
+			}
+		};
+
+		void fetchCourseDetails();
+
+		return () => {
+			controller.abort();
+		};
+	}, [courseDetails, fetchError, showPopover, value]);
+
+	useEffect(() => {
+		const onOtherPopoverOpen = (e: Event) => {
+			if ((e as CustomEvent).detail !== instanceId.current) {
+				setIsVisible(false);
+				setTimeout(() => setShowPopover(false), 150);
+			}
+		};
+		window.addEventListener('popover-open', onOtherPopoverOpen);
+		return () => window.removeEventListener('popover-open', onOtherPopoverOpen);
+	}, []);
+
+	useEffect(() => {
+		if (!showPopover) {
+			return;
+		}
+
+		const closePopover = () => {
+			setIsVisible(false);
+			setTimeout(() => {
+				setShowPopover(false);
+				triggerRef.current?.focus();
+			}, 150);
+		};
+		const onWindowChange = () => updatePopoverPosition();
+		const onOutsideClick = () => closePopover();
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				closePopover();
+			}
+		};
+		window.addEventListener('resize', onWindowChange);
+		window.addEventListener('scroll', onWindowChange, true);
+		window.addEventListener('click', onOutsideClick);
+		window.addEventListener('keydown', onKeyDown);
+
+		return () => {
+			window.removeEventListener('resize', onWindowChange);
+			window.removeEventListener('scroll', onWindowChange, true);
+			window.removeEventListener('click', onOutsideClick);
+			window.removeEventListener('keydown', onKeyDown);
+		};
+	}, [showPopover]);
+
+	const popoverContent = showPopover ? (
+		<div
+			onClick={(e) => e.stopPropagation()}
+			style={{
+				position: 'fixed',
+				top: `${popoverPosition.top}px`,
+				left: `${popoverPosition.left}px`,
+				zIndex: 60,
+				width: `min(${PANEL_WIDTH}px, calc(100vw - 24px))`,
+				maxHeight: `min(calc(100vh - ${popoverPosition.top}px - 20px), 70vh)`,
+				overflow: 'hidden',
+				backgroundColor: '#fff',
+				borderRadius: '8px',
+				boxShadow: '10px 10px 20px rgba(0, 0, 0, 0.4)',
+				opacity: isVisible ? 1 : 0,
+				transform: isVisible ? 'scale(1)' : 'scale(0.96)',
+				transformOrigin: 'left center',
+				transition: 'opacity 0.15s ease, transform 0.15s ease',
+			}}
+		>
+			<div
+				ref={popoverScrollRef}
+				onScroll={checkScrollGradient}
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					overflowY: 'auto',
+					maxHeight: `min(calc(100vh - ${popoverPosition.top}px - 20px), 70vh)`,
+					minHeight: courseDetails ? 0 : `min(calc(100vh - ${popoverPosition.top}px - 20px), 70vh)`,
+					padding: '22px',
+					transition: 'min-height 0.3s ease',
+				}}
+			>
+				{courseDetails ? (
+					<div style={{ display: 'flex', flexDirection: 'column', width: '100%', gap: '10px' }}>
+						{/* Header */}
+						<div
+							style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}
+						>
+							{/* Left: chip, then tags, then title */}
+							<div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+								<div
+									style={{
+										backgroundImage: getDepartmentGradient(dept, 180),
+										color: 'white',
+										padding: '6px 16px',
+										borderRadius: '6px',
+										fontWeight: 600,
+										fontSize: '1.1rem',
+										width: 'fit-content',
+										boxShadow: '0 0 0 1px rgba(63,63,68,0.05), 0 1px 3px 0 rgba(34,33,81,0.15)',
+									}}
+								>
+									{value}
+								</div>
+								<div style={{ display: 'flex', gap: '6px' }}>
+									{distShort && (
+										<Tooltip title={distTitle} variant='soft'>
+											<div
+												style={{
+													backgroundColor: distColor,
+													color: 'white',
+													padding: '2px 10px',
+													borderRadius: '8px',
+													fontWeight: '600',
+													fontSize: '0.8rem',
+													display: 'flex',
+													alignItems: 'center',
+												}}
+											>
+												{distShort}
+											</div>
+										</Tooltip>
+									)}
+									{pdfTag && (
+										<Tooltip title={pdfTitle} variant='soft'>
+											<div
+												style={{
+													backgroundColor: pdfColor,
+													color: 'white',
+													padding: '2px 10px',
+													borderRadius: '8px',
+													fontWeight: '600',
+													fontSize: '0.8rem',
+													display: 'flex',
+													alignItems: 'center',
+												}}
+											>
+												{pdfTag}
+											</div>
+										</Tooltip>
+									)}
+									{auditTag && (
+										<Tooltip title={auditTitle} variant='soft'>
+											<div
+												style={{
+													backgroundColor: auditColor,
+													color: 'white',
+													padding: '2px 10px',
+													borderRadius: '8px',
+													fontWeight: '600',
+													fontSize: '0.8rem',
+													display: 'flex',
+													alignItems: 'center',
+												}}
+											>
+												{auditTag}
+											</div>
+										</Tooltip>
+									)}
+								</div>
+								{courseDetails['Title'] && (
+									<h3 style={{ margin: 0, fontSize: '1.0rem', fontWeight: 600 }}>
+										{String(courseDetails['Title'])}
+									</h3>
+								)}
+							</div>
+							{/* Right: external links */}
+							<div style={{ display: 'flex', alignItems: 'stretch', gap: '8px', flexShrink: 0 }}>
+								{links.princeton && (
+									<ExternalLink href={links.princeton}>
+										Princeton
+										<br />
+										Courses
+									</ExternalLink>
+								)}
+								{links.registrar && (
+									<ExternalLink href={links.registrar}>
+										Official
+										<br />
+										Registrar
+									</ExternalLink>
+								)}
+							</div>
+						</div>
+
+						{/* Term row + dropdown */}
+						{selectedTerm && (
+							<div style={{ borderRadius: '6px', border: '1px solid #e5e7eb', overflow: 'hidden' }}>
+								{/* Header row — click to toggle dropdown */}
+								<div
+									role='button'
+									tabIndex={0}
+									onClick={(e) => {
+										e.stopPropagation();
+										setShowTermDropdown((prev) => !prev);
+									}}
+									onKeyDown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											setShowTermDropdown((prev) => !prev);
+										}
+									}}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: '10px',
+										padding: '6px 8px',
+										backgroundColor: '#fafafa',
+										cursor: 'pointer',
+										userSelect: 'none',
+									}}
+								>
+									{termTagSeason && (
+										<SemesterTag semester={termTagSeason} year={termYear || undefined} />
+									)}
+									<span
+										style={{
+											flex: 1,
+											fontSize: '0.82rem',
+											color: '#555',
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											whiteSpace: 'nowrap',
+										}}
+									>
+										{selectedTerm.instructors.join(', ')}
+									</span>
+									{selectedTerm.quality_of_course != null ? (
+										<div
+											style={{
+												background: getRatingBackground(selectedTerm.quality_of_course),
+												color: 'white',
+												padding: '2px 8px',
+												borderRadius: '4px',
+												fontWeight: 700,
+												fontSize: '0.82rem',
+												flexShrink: 0,
+											}}
+										>
+											{selectedTerm.quality_of_course.toFixed(2)}
+										</div>
+									) : (
+										<div
+											style={{
+												backgroundColor: '#d1d5db',
+												color: '#6b7280',
+												padding: '2px 8px',
+												borderRadius: '4px',
+												fontWeight: 700,
+												fontSize: '0.82rem',
+												flexShrink: 0,
+											}}
+										>
+											N/A
+										</div>
+									)}
+									<div style={{ flexShrink: 0, color: '#9ca3af', display: 'flex' }}>
+										{showTermDropdown ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+									</div>
+								</div>
+
+								{/* Dropdown list */}
+								{showTermDropdown && terms.length > 1 && (
+									<div
+										style={{
+											maxHeight: '220px',
+											overflowY: 'auto',
+											borderTop: '1px solid #e5e7eb',
+										}}
+									>
+										{terms.map((term, i) => (
+											<div
+												key={term.term_code}
+												role='button'
+												tabIndex={0}
+												onClick={(e) => {
+													e.stopPropagation();
+													setSelectedTermIdx(i);
+													setShowTermDropdown(false);
+												}}
+												onKeyDown={(e) => {
+													if (e.key === 'Enter' || e.key === ' ') {
+														setSelectedTermIdx(i);
+														setShowTermDropdown(false);
+													}
+												}}
+												style={{
+													display: 'flex',
+													alignItems: 'center',
+													gap: '10px',
+													padding: '7px 10px',
+													cursor: 'pointer',
+													backgroundColor: i === selectedTermIdx ? '#e8f0fe' : 'white',
+													borderBottom: i < terms.length - 1 ? '1px solid #f3f4f6' : 'none',
+												}}
+											>
+												<span
+													style={{
+														fontWeight: i === selectedTermIdx ? 700 : 600,
+														fontSize: '0.82rem',
+														color: i === selectedTermIdx ? '#1d4ed8' : '#374151',
+														minWidth: '88px',
+														flexShrink: 0,
+													}}
+												>
+													{term.label}
+												</span>
+												<span
+													style={{
+														flex: 1,
+														fontSize: '0.8rem',
+														color: '#6b7280',
+														overflow: 'hidden',
+														textOverflow: 'ellipsis',
+														whiteSpace: 'nowrap',
+													}}
+												>
+													{term.instructors.join(', ')}
+												</span>
+												{term.quality_of_course != null ? (
+													<div
+														style={{
+															background: getRatingBackground(term.quality_of_course),
+															color: 'white',
+															padding: '1px 7px',
+															borderRadius: '4px',
+															fontWeight: 700,
+															fontSize: '0.78rem',
+															flexShrink: 0,
+														}}
+													>
+														{term.quality_of_course.toFixed(2)}
+													</div>
+												) : (
+													<div
+														style={{
+															backgroundColor: '#d1d5db',
+															color: '#6b7280',
+															padding: '1px 7px',
+															borderRadius: '4px',
+															fontWeight: 700,
+															fontSize: '0.78rem',
+															flexShrink: 0,
+														}}
+													>
+														N/A
+													</div>
+												)}
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						)}
+
+						{/* Instructors + Course Setup side by side */}
+						<div style={{ display: 'flex', gap: '16px' }}>
+							<div style={{ flex: 1 }}>
+								<SectionTitle label='Instructors' iconSrc='/icons/instructors.svg' />
+								<CourseDetailSection>
+									<div
+										style={{
+											fontSize: '0.85rem',
+											fontWeight: 600,
+											display: 'flex',
+											flexDirection: 'column',
+										}}
+									>
+										{selectedTerm && selectedTerm.instructors.length > 0 ? (
+											selectedTerm.instructors.map((name, index, arr) => (
+												<div
+													key={index}
+													style={{
+														paddingBottom: index !== arr.length - 1 ? '5px' : '0px',
+														marginBottom: index !== arr.length - 1 ? '5px' : '0px',
+														borderBottom: index !== arr.length - 1 ? '1px solid #ccc' : 'none',
+													}}
+												>
+													{name}
+												</div>
+											))
+										) : (
+											<div>No instructor listed</div>
+										)}
+									</div>
+								</CourseDetailSection>
+							</div>
+							<div style={{ flex: 1 }}>
+								<SectionTitle label='Course Setup' iconSrc='/icons/course-setup.svg' />
+								<CourseDetailSection>
+									<CourseSetup courseSetup={courseSetup} />
+								</CourseDetailSection>
+							</div>
+						</div>
+
+						{/* Description */}
+						<div>
+							<SectionTitle label='Description' iconSrc='/icons/description.svg' />
+							<CourseDetailSection>
+								<div style={{ fontSize: '0.85rem', lineHeight: 1.4 }}>
+									{String(selectedDescription ?? '')}
+								</div>
+							</CourseDetailSection>
+						</div>
+
+						{/* Grading */}
+						{Array.isArray(selectedGrading) &&
+							selectedGrading.length > 0 &&
+							(selectedGrading as unknown[]).every(
+								(g) => typeof g === 'object' && g !== null && 'label' in g && 'percent' in g
+							) && (
+								<div>
+									<SectionTitle label='Grading' iconSrc='/icons/description.svg' />
+									<CourseDetailSection>
+										<div
+											style={{
+												fontSize: '0.85rem',
+												fontWeight: 600,
+												display: 'flex',
+												flexDirection: 'column',
+											}}
+										>
+											{(selectedGrading as { label: string; percent: number }[]).map(
+												(item, index, arr) => (
+													<div
+														key={item.label}
+														style={{
+															paddingBottom: index !== arr.length - 1 ? '5px' : '0px',
+															marginBottom: index !== arr.length - 1 ? '5px' : '0px',
+															borderBottom: index !== arr.length - 1 ? '1px solid #ccc' : 'none',
+														}}
+													>
+														{item.percent}% {item.label}
+													</div>
+												)
+											)}
+										</div>
+									</CourseDetailSection>
+								</div>
+							)}
+
+						{/* Student Feedback */}
+						<div>
+							<div
+								style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+							>
+								<SectionTitle label='Student Feedback' iconSrc='/icons/feedback.svg' />
+								{selectedQuality !== null &&
+									selectedQuality !== undefined &&
+									selectedQuality > 0 && (
+										<div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+											<span style={{ fontSize: '0.75rem', color: '#8b8b8b', fontWeight: 600 }}>
+												{selectedQuality.toFixed(2)}
+											</span>
+											<Rating value={selectedQuality} precision={0.1} readOnly size='small' />
+										</div>
+									)}
+							</div>
+							<div
+								style={{
+									backgroundColor: '#F5F5F5',
+									borderRadius: '6px',
+									border: '1px solid rgba(205, 215, 225, 1)',
+									padding: '12px',
+								}}
+							>
+								<ReviewMenu dept={dept} coursenum={coursenum} term_code={selectedTermCode} />
+							</div>
+						</div>
+					</div>
+				) : (
+					<div
+						style={{
+							flex: 1,
+							display: 'flex',
+							justifyContent: 'center',
+							alignItems: 'center',
+						}}
+					>
+						<CircularProgress size={30} sx={{ color: '#9e9e9e' }} />
+					</div>
+				)}
+			</div>
+			<div
+				style={{
+					position: 'absolute',
+					bottom: 0,
+					left: 0,
+					right: 0,
+					height: '40px',
+					background: 'linear-gradient(to bottom, transparent, rgba(200, 200, 200, 0.6))',
+					pointerEvents: 'none',
+					borderRadius: '0 0 8px 8px',
+					opacity: showScrollGradient ? 1 : 0,
+					transition: 'opacity 0.2s ease',
+				}}
+			/>
+		</div>
+	) : null;
+
+	return (
+		<>
+			<div ref={triggerRef} tabIndex={-1} onClick={togglePopover}>
+				{children}
+			</div>
+			{popoverContent && createPortal(popoverContent, document.body)}
+		</>
+	);
+};

--- a/frontend/components/Item/Item.tsx
+++ b/frontend/components/Item/Item.tsx
@@ -1,8 +1,11 @@
 import { type CSSProperties, type ReactNode } from 'react';
 import { memo, forwardRef, useEffect } from 'react'; // todo: not needed in react19
 
-import { InfoComponent } from '@/components/InfoComponent';
+import { InfoComponentPopOver } from '@/components/InfoComponent/InfoComponentPopOver';
 import { cn } from '@/lib/utils';
+import type { Course } from '@/types';
+
+import infoStyles from '../InfoComponent/InfoComponent.module.css';
 
 import { Handle, Remove } from './components';
 import styles from './Item.module.css';
@@ -28,6 +31,9 @@ export type Props = {
 	transition?: string | null;
 	wrapperStyle?: CSSProperties;
 	value: ReactNode; // Note: This should be the text that appears on the course card
+	// Backing course record, used to identify the exact course for the info
+	// popover instead of guessing from the (possibly multi-crosslisting) label.
+	course?: Course;
 	onRemove?(): void;
 };
 
@@ -37,6 +43,7 @@ export const Item = memo(
 			{
 				color_primary,
 				color_secondary,
+				course,
 				dragOverlay,
 				dragging,
 				disabled,
@@ -117,7 +124,24 @@ export const Item = memo(
 						{/* Text Container for InfoComponent */}
 						<div className={styles.TextContainer}>
 							{!disabled ? (
-								<InfoComponent value={value.toString().split('|')[1] ?? ''} />
+								<InfoComponentPopOver
+									value={value.toString().split('|')[1] ?? ''}
+									dept={course?.department_code}
+									coursenum={course ? String(course.catalog_number) : undefined}
+								>
+									<div
+										className={infoStyles.Action}
+										style={{
+											cursor: 'pointer',
+											maxWidth: '100%',
+											overflow: 'hidden',
+											whiteSpace: 'nowrap',
+											textOverflow: 'ellipsis',
+										}}
+									>
+										{value.toString().split('|')[1] ?? ''}
+									</div>
+								</InfoComponentPopOver>
 							) : (
 								(value.toString().split('|')[1] ?? '')
 							)}

--- a/frontend/components/ReviewMenu.tsx
+++ b/frontend/components/ReviewMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FC } from 'react';
+import { useEffect, useRef, useState, type FC } from 'react';
 
 import { CircularProgress } from '@mui/material';
 
@@ -7,6 +7,7 @@ import { AISummary } from '@/components/ui/AISummary';
 interface ReviewMenuProps {
 	dept: string;
 	coursenum: string;
+	term_code?: string;
 	onRatingLoaded?: (rating: number) => void;
 	onSummaryLoaded?: (summary: string) => void;
 }
@@ -14,6 +15,7 @@ interface ReviewMenuProps {
 export const ReviewMenu: FC<ReviewMenuProps> = ({
 	dept,
 	coursenum,
+	term_code,
 	onRatingLoaded,
 	onSummaryLoaded,
 }) => {
@@ -21,37 +23,64 @@ export const ReviewMenu: FC<ReviewMenuProps> = ({
 	const [loading, setLoading] = useState<boolean>(true);
 	const [summary, setSummary] = useState<string>('');
 
+	// Keep latest callbacks in refs — stable identity, never stale
+	const onRatingLoadedRef = useRef(onRatingLoaded);
+	const onSummaryLoadedRef = useRef(onSummaryLoaded);
 	useEffect(() => {
-		if (dept && coursenum) {
-			const fetchReviews = async () => {
-				try {
-					setLoading(true);
+		onRatingLoadedRef.current = onRatingLoaded;
+	}, [onRatingLoaded]);
+	useEffect(() => {
+		onSummaryLoadedRef.current = onSummaryLoaded;
+	}, [onSummaryLoaded]);
 
-					const params = new URLSearchParams({ dept, coursenum });
-					const response = await fetch(`/api/hoagie/course/comments?${params}`);
+	useEffect(() => {
+		if (!dept || !coursenum) {
+			return;
+		}
 
-					const data = await response.json();
-					if (data?.reviews) {
-						setReviews(data.reviews);
-					}
-					if (data?.rating) {
-						onRatingLoaded?.(data.rating);
-					}
-					if (data?.summary) {
-						setSummary(data.summary);
-						onSummaryLoaded?.(data.summary);
-					}
-				} catch (err) {
+		const controller = new AbortController();
+
+		const fetchReviews = async () => {
+			try {
+				setLoading(true);
+				const params = new URLSearchParams({ dept, coursenum });
+				if (term_code) {
+					params.append('term_code', term_code);
+				}
+
+				const response = await fetch(`/api/hoagie/course/comments?${params}`, {
+					signal: controller.signal,
+				});
+				const data = await response.json();
+
+				if (data?.reviews) {
+					setReviews(data.reviews);
+				}
+				if (data?.rating) {
+					onRatingLoadedRef.current?.(data.rating);
+				}
+				if (data?.summary) {
+					setSummary(data.summary);
+					onSummaryLoadedRef.current?.(data.summary);
+				}
+			} catch (err) {
+				if ((err as Error).name !== 'AbortError') {
 					console.error('Error fetching course reviews:', err);
 					setReviews([]);
-				} finally {
+				}
+			} finally {
+				// Only clear loading if this effect instance wasn't cancelled
+				if (!controller.signal.aborted) {
 					setLoading(false);
 				}
-			};
+			}
+		};
 
-			void fetchReviews();
-		}
-	}, [dept, coursenum, onRatingLoaded, onSummaryLoaded]);
+		void fetchReviews();
+		return () => controller.abort();
+
+		// Callbacks intentionally excluded — accessed via stable refs above
+	}, [dept, coursenum, term_code, onRatingLoaded, onSummaryLoaded]);
 
 	if (loading) {
 		return (

--- a/frontend/components/Search.tsx
+++ b/frontend/components/Search.tsx
@@ -278,6 +278,11 @@ export const Search: FC = () => {
 						options={Object.keys(terms)}
 						placeholder='Semester'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={termsInverse[localTermFilter]}
 						isOptionEqualToValue={(option, value) => value === '' || option === value}
 						onChange={(event, newTermName: string | null) => {
@@ -300,6 +305,11 @@ export const Search: FC = () => {
 						options={Object.keys(distributionAreas)}
 						placeholder='Distribution area'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={localDistributionFilters.map(
 							(distribution) => distributionAreasInverse[distribution]
 						)}

--- a/frontend/components/UserSettings.tsx
+++ b/frontend/components/UserSettings.tsx
@@ -169,6 +169,11 @@ export const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => 
 						filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)}
 						placeholder='Select your major'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={major}
 						// inputValue={major.code === undeclared.code ? '' : major.code}
 						isOptionEqualToValue={isOptionEqual}
@@ -197,6 +202,11 @@ export const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => 
 						filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)}
 						placeholder='Select your minor(s)'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={minors}
 						isOptionEqualToValue={isOptionEqual}
 						onChange={(event, newMinors: MajorMinorType[]) => {
@@ -239,6 +249,11 @@ export const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => 
 						filterOptions={(options, { inputValue }) => smartSearch(inputValue, options)}
 						placeholder='Select your certificate(s)'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={certificates}
 						isOptionEqualToValue={isOptionEqual}
 						onChange={(event, newCertificates: MajorMinorType[]) => {
@@ -320,6 +335,11 @@ export const UserSettings: FC<ProfileProps> = ({ profile, onClose, onSave }) => 
 						options={generateClassYears()}
 						placeholder='Class year'
 						variant='soft'
+						slotProps={{
+							listbox: {
+								disablePortal: true,
+							},
+						}}
 						value={classYear}
 						isOptionEqualToValue={(option, value) => value === undefined || option === value}
 						onChange={(event, newClassYear: number | undefined) => {

--- a/frontend/public/dashboard.json
+++ b/frontend/public/dashboard.json
@@ -15,5 +15,12 @@
 		"<span style=\"font-weight: 500;\">1. Click Almost Completed Minors in the top left <br> 2. Check which minors/certificates you’re close to completing! You can see which requirements or prerequisites you’re missing <br> 3. Add minors to your plan as desired </span>",
 		"<span style=\"font-weight: 500;\">Some courses can only count towards one of multiple requirements. They are displayed in red. Click on the course to settle it into your desired requirement. </span>"
 	],
-	"photos": ["/profile.png", "/transcript.png", "/search.png", "/requirement.png", "/almost_completed_minors.png", "/settle.png"]
+	"photos": [
+		"/profile.png",
+		"/transcript.png",
+		"/search.png",
+		"/requirement.png",
+		"/almost_completed_minors.png",
+		"/settle.png"
+	]
 }


### PR DESCRIPTION
**References**
- Linear: https://linear.app/hoagie/issue/DEV-678/info-component-popover-ui

**Proposed Changes**
- **Popover replaces modal.** `InfoComponentPopOver` renders course details anchored to the search result instead of opening a full-screen modal. `SortableItem` wraps search-result items in the popover. 
- **Semester-specific feedback.** Reads term history from `/course/details/` and passes `term_code` to `/course/comments/` so reviews reflect the selected semester. Term selection defaults to the newest term that actually has feedback, rather than walking the term list by index.
- **Fetch retry.** Error state is tracked separately from `courseDetails`, so a failed detail fetch no longer sticks — reopening the popover retries instead of showing a cached error. Successful responses stay cached.

**Follow-Up Notes / Known Bugs**
- Notice that as we switch between terms, grading isn't updated. I created a [new issue](https://linear.app/hoagie/issue/DEV-745/make-grading-breakdown-term-specific-in-course-detail-popover) to deal with this. 
- When we switch between terms, the rating in the request body is not changing, I created a [new issue](https://linear.app/hoagie/issue/DEV-746/make-displayed-course-rating-term-specific) for this. 